### PR TITLE
Format weights in weigh in list to first decimal

### DIFF
--- a/web/src/app/weighin/weighin-list/weighin-list.component.html
+++ b/web/src/app/weighin/weighin-list/weighin-list.component.html
@@ -1,7 +1,7 @@
 <div *ngFor="let weighIn of getWeighInListForDisplay()">
     <div class="element">
         <span>
-            {{weighIn.weight}}
+            {{formatWeighInWeight(weighIn.weight)}}
         </span>
         <span class="weighInDate">
             {{formatWeighinTimestamp(weighIn.date)}}

--- a/web/src/app/weighin/weighin-list/weighin-list.component.spec.ts
+++ b/web/src/app/weighin/weighin-list/weighin-list.component.spec.ts
@@ -41,4 +41,16 @@ describe('WeighinListComponent', () => {
         const result = component.getWeighInListForDisplay();
         expect(result.length).toBe(25);
     });
+
+    describe('formatWeighIn', () => {
+        it('should round weigh ins with long decimals to the first decimal place', () => {
+            expect(component.formatWeighInWeight(201.16)).toBe('201.2');
+        });
+        it('should pad no decimals to the first decimal place with a zero', () => {
+          expect(component.formatWeighInWeight(201)).toBe('201.0');
+        });
+        it('should do nothing to first decimal place number', () => {
+          expect(component.formatWeighInWeight(201.1)).toBe('201.1');
+        });
+    });
 });

--- a/web/src/app/weighin/weighin-list/weighin-list.component.ts
+++ b/web/src/app/weighin/weighin-list/weighin-list.component.ts
@@ -36,4 +36,8 @@ export class WeighinListComponent implements OnInit {
         const weighInDate = new Date(timestamp);
         return `${weighInDate.getMonth()}-${weighInDate.getDay()}-${weighInDate.getFullYear()}`;
     }
+
+    formatWeighInWeight(weighInWeight: number): string {
+      return weighInWeight.toFixed(1) + '';
+    }
 }


### PR DESCRIPTION
## Overview
Adds the feature outlined in #4 . 

## Testing Instructions
Logging into the website and creating weigh ins with weights of 201.1, 201, and 201.11 should show results that look like `201.1, 201.0, 201.1`.