### PR TITLE
Fix incorrect weigh in list date calculation where they were off by one

### DIFF
--- a/web/src/app/weighin/weighin-list/weighin-list.component.spec.ts
+++ b/web/src/app/weighin/weighin-list/weighin-list.component.spec.ts
@@ -1,4 +1,3 @@
-
 import {WeighinListComponent} from './weighin-list.component';
 import {WeighIn} from '../weighin';
 import {WeighInService} from '../weigh-in.service';
@@ -47,10 +46,16 @@ describe('WeighinListComponent', () => {
             expect(component.formatWeighInWeight(201.16)).toBe('201.2');
         });
         it('should pad no decimals to the first decimal place with a zero', () => {
-          expect(component.formatWeighInWeight(201)).toBe('201.0');
+            expect(component.formatWeighInWeight(201)).toBe('201.0');
         });
         it('should do nothing to first decimal place number', () => {
-          expect(component.formatWeighInWeight(201.1)).toBe('201.1');
+            expect(component.formatWeighInWeight(201.1)).toBe('201.1');
+        });
+    });
+
+    describe('formatTimestamp', () => {
+        it('should correctly convert unix timestamp into date', () => {
+            expect(component.formatWeighinTimestamp(1543761377688)).toBe('12-02-2018');
         });
     });
 });

--- a/web/src/app/weighin/weighin-list/weighin-list.component.ts
+++ b/web/src/app/weighin/weighin-list/weighin-list.component.ts
@@ -34,7 +34,8 @@ export class WeighinListComponent implements OnInit {
 
     formatWeighinTimestamp(timestamp: number) {
         const weighInDate = new Date(timestamp);
-        return `${weighInDate.getMonth()}-${weighInDate.getDay()}-${weighInDate.getFullYear()}`;
+        const formattedDay = (weighInDate.getDate() + '').padStart(2, '0');
+        return `${weighInDate.getMonth() + 1}-${formattedDay}-${weighInDate.getFullYear()}`;
     }
 
     formatWeighInWeight(weighInWeight: number): string {


### PR DESCRIPTION
## Overview
Makes it so that the weigh in dates are calculated correctly.

### Demo
Creating a weigh in on December 2nd will show a list like so:
```
222.1   12-02-18
```

## Testing Instructions
Log into an account, create a weigh in, verify that the generated date is today's date.