### PR TITLE
Login shows error message when it fails

### DIFF
--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { WeighInAverageComponent } from './weighin/weigh-in-average/weigh-in-ave
 import { WeighInCreateButtonComponent } from './weighin/weigh-in-create-button/weigh-in-create-button.component';
 import { WeighInCreateComponent } from './weighin/weigh-in-create/weigh-in-create.component';
 import {UrlInterceptor} from './util/http-interceptor.interceptor';
+import { RequestComponent } from './request/request.component';
 
 @NgModule({
     declarations: [
@@ -24,7 +25,8 @@ import {UrlInterceptor} from './util/http-interceptor.interceptor';
         WeighinListComponent,
         WeighInAverageComponent,
         WeighInCreateButtonComponent,
-        WeighInCreateComponent
+        WeighInCreateComponent,
+        RequestComponent
     ],
     imports: [
         HttpClientModule,

--- a/web/src/app/login/login.component.css
+++ b/web/src/app/login/login.component.css
@@ -1,0 +1,5 @@
+.requestError {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    width: 400px;
+}

--- a/web/src/app/login/login.component.html
+++ b/web/src/app/login/login.component.html
@@ -13,4 +13,7 @@
     password
     <input type="password" [(ngModel)]="password">
 </div>
+<div class="requestError" *ngIf="loginFailed">
+    <app-request></app-request>
+</div>
 <button (click)="handleLogin()">Login</button>

--- a/web/src/app/login/login.component.spec.ts
+++ b/web/src/app/login/login.component.spec.ts
@@ -2,17 +2,19 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {LoginComponent} from './login.component';
 import {LoginService} from './login.service';
-import {Observable} from 'rxjs';
+import {Observable, Subject} from 'rxjs';
 import {Router} from '@angular/router';
 
 describe('LoginComponent', () => {
     let mockLoginService: LoginService;
     let mockRouter: Router;
     let component: LoginComponent;
+    let mockLoginSubject: Subject<any>;
 
     beforeEach(async(() => {
+        mockLoginSubject = new Subject();
         mockLoginService = jasmine.createSpyObj({
-            login: new Observable()
+            login: mockLoginSubject
         });
         mockRouter = jasmine.createSpyObj({
             navigate: new Observable()
@@ -22,5 +24,19 @@ describe('LoginComponent', () => {
 
     it('should be truthy', () => {
         expect(component).toBeTruthy();
+        expect(component.loginFailed).toBeFalsy();
+    });
+
+    describe('handleLogin', () => {
+        it('should call navigate on success', () => {
+            component.handleLogin();
+            mockLoginSubject.next({});
+            expect(mockRouter.navigate).toHaveBeenCalledWith(['/dashboard']);
+        });
+        it('should update when login fails', () => {
+            component.handleLogin();
+            mockLoginSubject.error({});
+            expect(component.loginFailed).toBeTruthy();
+        });
     });
 });

--- a/web/src/app/login/login.component.ts
+++ b/web/src/app/login/login.component.ts
@@ -11,11 +11,13 @@ export class LoginComponent implements OnInit {
 
     username: string;
     password: string;
+    loginFailed: boolean;
 
     constructor(
         private router: Router,
         private loginService: LoginService
     ) {
+        this.loginFailed = false;
     }
 
     ngOnInit() {
@@ -25,7 +27,7 @@ export class LoginComponent implements OnInit {
         this.loginService.login(this.username, this.password).subscribe((res) => {
             this.router.navigate(['/dashboard']);
         }, (err) => {
-            // do something I guess
+            this.loginFailed = true;
         });
     }
 

--- a/web/src/app/login/login.service.spec.ts
+++ b/web/src/app/login/login.service.spec.ts
@@ -3,16 +3,18 @@ import {TestBed, inject} from '@angular/core/testing';
 import {LoginService} from './login.service';
 import {HttpClient} from '@angular/common/http';
 import {AuthService} from '../auth/auth.service';
-import {Observable} from 'rxjs';
+import {Observable, Subject} from 'rxjs';
 
 describe('LoginService', () => {
     let service: LoginService;
     let mockHttpClient: HttpClient;
     let mockAuthService: AuthService;
+    let mockHttpSubject: Subject<any>;
 
     beforeEach(() => {
+        mockHttpSubject = new Subject();
         mockHttpClient = jasmine.createSpyObj({
-            post: new Observable()
+            post: mockHttpSubject
         });
         mockAuthService = jasmine.createSpyObj({
             setToken: null
@@ -22,5 +24,18 @@ describe('LoginService', () => {
 
     it('should be truthy', () => {
         expect(service).toBeTruthy();
+    });
+
+    describe('login', () => {
+        it('should be able to pass on errors', () => {
+            let result = true;
+            service.login('username', 'password').subscribe(() => {
+                result = true;
+            }, () => {
+                result = false;
+            });
+            mockHttpSubject.error({});
+            expect(result).toBeFalsy();
+        });
     });
 });

--- a/web/src/app/login/login.service.ts
+++ b/web/src/app/login/login.service.ts
@@ -29,11 +29,13 @@ export class LoginService {
                     'Content-Type': 'application/json'
                 })
             };
-            this.http.post<string>(url, {username: username, password: password}, httpOptions).subscribe(response => {
+            this.http.post<any>(url, {username: username, password: password}, httpOptions).subscribe(response => {
                 if (response) {
                     this.authService.setToken(`Bearer ${response['token']}`);
                 }
                 observer.next(response);
+            }, () => {
+                observer.error();
             });
         });
     }

--- a/web/src/app/request/request.component.css
+++ b/web/src/app/request/request.component.css
@@ -1,0 +1,14 @@
+.requestInner {
+    background-color: #ff8a84;
+    padding: 1rem;
+    border-radius: .25rem;
+    border-style: solid;
+    border-width: .3rem;
+    border-color: #e67b76;
+}
+
+.requestOuter {
+    background-color: #ff8a84;
+    padding: .3rem;
+    border-radius: .25rem;
+}

--- a/web/src/app/request/request.component.html
+++ b/web/src/app/request/request.component.html
@@ -1,0 +1,5 @@
+<div class="requestOuter">
+    <div class="requestInner">
+        Request failed! Please try again!
+    </div>
+</div>

--- a/web/src/app/request/request.component.spec.ts
+++ b/web/src/app/request/request.component.spec.ts
@@ -1,0 +1,15 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {RequestComponent} from './request.component';
+
+describe('RequestComponent', () => {
+    let component: RequestComponent;
+
+    beforeEach(() => {
+        component = new RequestComponent();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/web/src/app/request/request.component.ts
+++ b/web/src/app/request/request.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-request',
+  templateUrl: './request.component.html',
+  styleUrls: ['./request.component.css']
+})
+export class RequestComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
## Overview
Currently, when failing to login for any reason scalio won't do anything. This is really confusing for users because they don't know if the request is complete or not. This PR will add an error box to show that a login has failed when it has.

### Demo
Optional display of what changes have been made. Include `examples of commands and output`.
![image](https://user-images.githubusercontent.com/18236455/49692347-767c8080-fb26-11e8-9e3a-b527610fa7eb.png)

## Testing Instructions
Attempt to log in with any account that doesn't currently exist in the system, and observe that there is an error box.