### PR TITLE
Display error message when registration fails

### DIFF
--- a/web/src/app/regiser/regiser.component.css
+++ b/web/src/app/regiser/regiser.component.css
@@ -1,0 +1,5 @@
+.errorBox {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    width: 400px;
+}

--- a/web/src/app/regiser/regiser.component.html
+++ b/web/src/app/regiser/regiser.component.html
@@ -12,4 +12,7 @@
     password
     <input type="password" [(ngModel)]="password">
 </div>
+<div class="errorBox" *ngIf="registrationFailed">
+    <app-request></app-request>
+</div>
 <button (click)="handleRegistration()">Register</button>

--- a/web/src/app/regiser/regiser.component.spec.ts
+++ b/web/src/app/regiser/regiser.component.spec.ts
@@ -3,24 +3,35 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {RegiserComponent} from './regiser.component';
 import {Router} from '@angular/router';
 import {LoginService} from '../login/login.service';
-import {Observable} from 'rxjs';
+import {Observable, Subject} from 'rxjs';
 
 describe('RegiserComponent', () => {
     let mockRouter: Router;
     let mockLoginService: LoginService;
     let component: RegiserComponent;
+    let mockRegisterSubject: Subject<any>;
 
     beforeEach(() => {
+        mockRegisterSubject = new Subject();
         mockRouter = jasmine.createSpyObj({
             navigate: new Observable()
         });
         mockLoginService = jasmine.createSpyObj({
-            register: new Observable()
+            register: mockRegisterSubject
         });
         component = new RegiserComponent(mockRouter, mockLoginService);
     });
 
     it('should create', () => {
         expect(component).toBeTruthy();
+        expect(component.registrationFailed).toBeFalsy();
+    });
+
+    describe('handleRegistration', () => {
+        it('should update when the service returns an error', () => {
+            component.handleRegistration();
+            mockRegisterSubject.error({});
+            expect(component.registrationFailed).toBeTruthy();
+        });
     });
 });

--- a/web/src/app/regiser/regiser.component.ts
+++ b/web/src/app/regiser/regiser.component.ts
@@ -9,24 +9,26 @@ import {Router} from '@angular/router';
 })
 export class RegiserComponent implements OnInit {
 
+    username: string;
+    password: string;
+    registrationFailed: boolean;
+
     constructor(
         private router: Router,
         private loginService: LoginService
     ) {
+        this.registrationFailed = false;
     }
-
-    username: string;
-    password: string;
 
     ngOnInit() {
     }
 
     public handleRegistration() {
         this.loginService.register(this.username, this.password).subscribe(
-            (res) => {
+            () => {
                 this.router.navigate(['dashboard']);
-            }, (err) => {
-
+            }, () => {
+                this.registrationFailed = true;
             }
         );
     }


### PR DESCRIPTION
## Overview
Currently, when failing to login for any reason scalio won't do anything. This is really confusing for users because they don't know if the request is complete or not. This PR will add an error box to show that a login has failed when it has.

Connects #3 

### Demo
![image](https://user-images.githubusercontent.com/18236455/49703175-d418d780-fbcf-11e8-85fb-73fec125e4cf.png)

## Testing Instructions
Create an account with an invalid email address and then see that the error pops up