### PR TITLE
Make the api return empty body on login/registration failures

### DIFF
--- a/api/scalio/users/controller.py
+++ b/api/scalio/users/controller.py
@@ -18,7 +18,7 @@ class UserRegistration(Resource):
         if not self._is_email(email):
             return None, 400
         if User.find_by_username(email):
-            return {}, 400
+            return None, 400
         new_user = User(
             email=email,
             password=bcrypt.hashpw(str.encode(data['password']), bcrypt.gensalt())
@@ -28,7 +28,7 @@ class UserRegistration(Resource):
                 'token': build_token(email)
             }
         except:
-            return {}, 500
+            return None, 500
 
     def _is_email(self, email: str):
         email_split_on_at = email.split('@')
@@ -56,13 +56,13 @@ class UserLogin(Resource):
         data = parser.parse_args()
         user = User.find_by_username(data['username'])
         if not user:
-            return {}, 404
+            return None, 404
         if bcrypt.checkpw(data['password'].encode('utf-8'), self.convert_to_by_if_neccessary(user.password)):
             return {
                 'token': build_token(data['username'])
             }
         else:
-            return {}, 404
+            return None, 404
 
 
 class UserAuthenticationApi(Resource):

--- a/api/test/user/test_user_api.py
+++ b/api/test/user/test_user_api.py
@@ -25,6 +25,17 @@ class UserRegistrationTestCase(TestCase):
         ))
         self.assertEqual(400, response.status_code)
 
+    def test_body_comes_back_empty_when_registering_same_user_twice(self):
+        self.app.post('/api/user/register', data=dict(
+            username='email@localhost',
+            password='password'
+        ))
+        response = self.app.post('/api/user/register', data=dict(
+            username='email@localhost',
+            password='password'
+        ))
+        self.assertIsNone(response.json)
+
     def test_email_must_conform_to_simple_formatting_rules(self):
         response = self.app.post('/api/user/register', data=dict(
             username='email@localhost',
@@ -46,6 +57,13 @@ class UserRegistrationTestCase(TestCase):
             password='password'
         ))
         self.assertEqual(400, response.status_code)
+
+    def test_invalid_email_returns_empty_body(self):
+        response = self.app.post('/api/user/register', data=dict(
+            username='notanemail@notadomain',
+            password='password'
+        ))
+        self.assertIsNone(response.json)
 
 
 class UserLoginTestCase(TestCase):
@@ -79,6 +97,24 @@ class UserLoginTestCase(TestCase):
             password='password'
         ))
         self.assertEqual(404, response.status_code)
+
+    def test_invalid_credentials_returns_empty_body(self):
+        self.app.post('/api/user/register', data=dict(
+            username='email@localhost',
+            password='password'
+        ))
+        response = self.app.post('/api/user/login', data=dict(
+            username='email@localhost',
+            password='incorrectpassword'
+        ))
+        self.assertIsNone(response.json)
+
+    def test_unregistered_username_returns_empty_body(self):
+        response = self.app.post('/api/user/login', data=dict(
+            username='email@localhost',
+            password='password'
+        ))
+        self.assertIsNone(response.json)
 
 
 class UserAuthenticatedApiTest(TestCase):


### PR DESCRIPTION
## Overview
Parts of the login and registration APIs return an empty json block instead of just return nothing. This PR will make that change.

## Notes
The API endpoints affected are `/api/user/register` and `/api/user/login`.

## Testing Instructions
_Null indicates that there was no body. I've removed the unneccesary parts of the curl response._

For giving an invalid email to register
```$ curl -d '{"username": "email@invaliddomain", "password": "password"}' -X POST -H "Content-Type: application/json" http://localhost:5000/api/user/register -i 
HTTP/1.0 400 BAD REQUEST
null
```

For registering a user more than once
```
$ curl -d '{"username": "email@localhost", "password": "password"}' -X POST -H "Content-Type: application/json" http://localhost:5000/api/user/register -i
HTTP/1.0 200 OK
{
    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbEBsb2NhbGhvc3QiLCJleHAiOjE1NDY3NDAxNDZ9.5xF-6KqmArl8aLmz0uL7U_ZD4rOGmf9T4i77bHfZnvQ"
}

$ curl -d '{"username": "email@localhost", "password": "password"}' -X POST -H "Content-Type: application/json" http://localhost:5000/api/user/register -i
HTTP/1.0 400 BAD REQUEST
null
```

For logging into an unregistered account
```
$ curl -d '{"username": "email@localhost", "password": "password"}' -X POST -H "Content-Type: application/json" http://localhost:5000/api/user/login -i  
HTTP/1.0 404 NOT FOUND
null
```

For providing an incorrect password
```
$ curl -d '{"username": "email@localhost", "password": "incorrectpassword"}' -X POST -H "Content-Type: application/json" http://localhost:5000/api/user/login -i 
HTTP/1.0 404 NOT FOUND
null
```